### PR TITLE
Rename configuration option removed in tox 4.0

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 # TODO: implement doc linting
 [tox]
-envlist = py{36,37,38,39}-lint, py36-lintreadme, py{36,37,38,39}-mypy, py{36,37,38,39}-unit
+envlist = py{37,38,39,310,311}-lint, py37-lintreadme, py{37,38,39,310,311}-mypy, py{37,38,39,310,311}-unit
 source_dir = gx_tool_db
 test_dir = tests
 
 [gh-actions]
 python =
-    3.6: py36-unit, py36-mypy, py36-lint, py36-lintdocs
-    3.7: py37-unit, py37-mypy
+    3.7: py37-unit, py37-mypy, py37-lint, py37-lintdocs
     3.8: py38-unit, py38-mypy
-    3.9: py39-unit, py39-mypy, py39-lint, py39-lintdocs
+    3.9: py39-unit, py39-mypy
+    3.10: py310-unit, py310-mypy
+    3.11: py311-unit, py311-mypy, py311-lint, py311-lintdocs
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ deps =
     lintreadme: readme
 skip_install =
     lint,lintdocstrings,lintreadme: True
-whitelist_externals =
+allowlist_externals =
     lintreadme: make


### PR DESCRIPTION
See https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4