### PR TITLE
Use vendored version parsing from galaxy-tool-util

### DIFF
--- a/gx_tool_db/db.py
+++ b/gx_tool_db/db.py
@@ -3,8 +3,8 @@ import shutil
 import tempfile
 from typing import Any, Dict, Iterator, List, Optional, Set
 
-import packaging.version
 import yaml
+from galaxy.tool_util import version
 
 from .config import FilterArguments, Server, TestDataMergeStrategy, ViewDefintion
 from .io import warn
@@ -598,4 +598,4 @@ def _version_sorted_keys(versions_dict: Dict[str, Any]) -> List[str]:
 
 
 def version_sorted_iterable(iterable) -> List[str]:
-    return list(sorted(iterable, key=packaging.version.parse, reverse=True))
+    return list(sorted(iterable, key=version.parse_version, reverse=True))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
+galaxy-tool-util
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 gspread
 gxformat2
-packaging
 pydantic<2
 requests
 pyyaml


### PR DESCRIPTION
Never checked the test results ... i guess it makes sense to use whatever galaxy uses for version parsing ?